### PR TITLE
Fix cleanup workflow to use Node.js instead of AWS CLI

### DIFF
--- a/.github/workflows/cleanup-feature.yml
+++ b/.github/workflows/cleanup-feature.yml
@@ -14,33 +14,26 @@ jobs:
     if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'feature/')
 
     steps:
-      - name: Setup AWS CLI
-        uses: aws-actions/configure-aws-credentials@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
+          node-version: '18'
+
+      - name: Install dependencies
+        run: npm ci
 
       - name: Delete feature deployment
-        run: |
-          BRANCH="${{ github.head_ref }}"
-          FEATURE_NAME=$(echo "$BRANCH" | sed 's|^feature/||' | sed 's|[^a-zA-Z0-9-_/]|-|g' | tr '[:upper:]' '[:lower:]')
-          BUCKET="${{ secrets.DO_SPACES_BUCKET }}"
-          ENDPOINT="${{ secrets.DO_SPACES_ENDPOINT }}"
-          PREFIX="cxone-expert-enhancements/feature/${FEATURE_NAME}/"
-
-          echo "Cleaning up feature deployment:"
-          echo "  Branch: $BRANCH"
-          echo "  Feature path: $PREFIX"
-          echo ""
-
-          # Delete all files in the feature path
-          aws s3 rm "s3://${BUCKET}/${PREFIX}" \
-            --recursive \
-            --endpoint-url "https://${ENDPOINT}"
-
-          echo ""
-          echo "✓ Feature deployment removed successfully"
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          DO_SPACES_BUCKET: ${{ secrets.DO_SPACES_BUCKET }}
+          DO_SPACES_ENDPOINT: ${{ secrets.DO_SPACES_ENDPOINT }}
+          GITHUB_HEAD_REF: ${{ github.head_ref }}
+          GITHUB_ACTIONS: 'true'
+        run: node cleanup-feature.js
 
       - name: Comment on PR
         uses: actions/github-script@v7

--- a/cleanup-feature.js
+++ b/cleanup-feature.js
@@ -1,0 +1,184 @@
+#!/usr/bin/env node
+
+import 'dotenv/config';
+import { execSync } from 'child_process';
+import { S3Client, ListObjectsV2Command, DeleteObjectsCommand } from "@aws-sdk/client-s3";
+
+// ============================================================================
+// Configuration
+// ============================================================================
+
+const CONFIG = {
+  bucket: process.env.DO_SPACES_BUCKET || 'benelliot-nice',
+  endpoint: process.env.DO_SPACES_ENDPOINT || 'syd1.digitaloceanspaces.com',
+  region: 'us-east-1',
+  basePrefix: 'cxone-expert-enhancements',
+};
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+function log(message) {
+  console.log(message);
+}
+
+function error(message) {
+  console.error(`[ERROR] ${message}`);
+}
+
+function sanitizeBranchName(branch) {
+  return branch
+    .replace(/^feature\//, '')
+    .replace(/[^a-zA-Z0-9-_\/]/g, '-')
+    .toLowerCase();
+}
+
+function getFeaturePath() {
+  // Get branch from environment (GitHub Actions provides GITHUB_HEAD_REF for PRs)
+  const branch = process.env.GITHUB_HEAD_REF || process.argv[2];
+
+  if (!branch) {
+    throw new Error('No branch specified. Set GITHUB_HEAD_REF or pass branch name as argument.');
+  }
+
+  if (!branch.startsWith('feature/')) {
+    throw new Error(`Branch "${branch}" is not a feature branch. Only feature/* branches can be cleaned up.`);
+  }
+
+  const featureName = sanitizeBranchName(branch);
+  const path = `${CONFIG.basePrefix}/feature/${featureName}/`;
+
+  return { branch, featureName, path };
+}
+
+// ============================================================================
+// S3 Cleanup
+// ============================================================================
+
+async function listObjects(s3Client, prefix) {
+  const command = new ListObjectsV2Command({
+    Bucket: CONFIG.bucket,
+    Prefix: prefix,
+  });
+
+  const response = await s3Client.send(command);
+  return response.Contents || [];
+}
+
+async function deleteObjects(s3Client, keys) {
+  if (keys.length === 0) {
+    log('No objects to delete');
+    return;
+  }
+
+  const command = new DeleteObjectsCommand({
+    Bucket: CONFIG.bucket,
+    Delete: {
+      Objects: keys.map(key => ({ Key: key })),
+    },
+  });
+
+  const response = await s3Client.send(command);
+  return response.Deleted || [];
+}
+
+// ============================================================================
+// Main Cleanup
+// ============================================================================
+
+async function cleanup() {
+  log('');
+  log('================================================================================');
+  log('Feature Deployment Cleanup');
+  log('================================================================================');
+  log('');
+
+  // Validate credentials
+  if (!process.env.AWS_ACCESS_KEY_ID || !process.env.AWS_SECRET_ACCESS_KEY) {
+    throw new Error('Missing AWS credentials. Set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY.');
+  }
+
+  log(`Bucket: ${CONFIG.bucket}`);
+  log(`Endpoint: ${CONFIG.endpoint}`);
+  log('');
+
+  // Get feature path
+  const { branch, featureName, path } = getFeaturePath();
+
+  log(`Branch: ${branch}`);
+  log(`Feature: ${featureName}`);
+  log(`Path to clean: ${path}`);
+  log('');
+
+  // Initialize S3 client
+  const s3Client = new S3Client({
+    region: CONFIG.region,
+    endpoint: `https://${CONFIG.endpoint}`,
+    credentials: {
+      accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+      secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+    },
+  });
+
+  // List objects
+  log('Listing objects...');
+  const objects = await listObjects(s3Client, path);
+
+  if (objects.length === 0) {
+    log('No objects found - path may already be clean or never existed');
+    log('');
+    log('================================================================================');
+    log('Cleanup Complete (nothing to delete)');
+    log('================================================================================');
+    return;
+  }
+
+  log(`Found ${objects.length} objects to delete:`);
+  objects.forEach(obj => log(`  - ${obj.Key}`));
+  log('');
+
+  // Delete objects
+  log('Deleting objects...');
+  const keys = objects.map(obj => obj.Key);
+  const deleted = await deleteObjects(s3Client, keys);
+
+  log(`Successfully deleted ${deleted.length} objects`);
+  log('');
+
+  // Summary
+  log('================================================================================');
+  log('Cleanup Complete!');
+  log('================================================================================');
+  log('');
+  log(`Removed deployment path: ${path}`);
+  log('');
+
+  // GitHub Actions output
+  if (process.env.GITHUB_ACTIONS === 'true') {
+    log(`::set-output name=cleaned_path::${path}`);
+    log(`::set-output name=branch::${branch}`);
+    log(`::set-output name=deleted_count::${deleted.length}`);
+  }
+}
+
+// ============================================================================
+// Run
+// ============================================================================
+
+(async () => {
+  try {
+    await cleanup();
+    process.exit(0);
+  } catch (err) {
+    log('');
+    log('================================================================================');
+    error('Cleanup Failed');
+    log('================================================================================');
+    error(err.message);
+    if (err.stack) {
+      console.error(err.stack);
+    }
+    process.exit(1);
+  }
+})();

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "deploy": "node deploy.js",
-    "deploy:v2": "node deploy-v2.js"
+    "deploy:v2": "node deploy-v2.js",
+    "cleanup": "node cleanup-feature.js"
   },
   "keywords": [
     "cxone",


### PR DESCRIPTION
## Summary

Fixes the cleanup workflow that failed because the AWS CLI authentication action doesn't work with Digital Ocean Spaces.

### Problem

The cleanup-feature.yml workflow was using `aws-actions/configure-aws-credentials@v4` which tries to authenticate with real AWS STS tokens. Digital Ocean Spaces doesn't support this, causing the workflow to fail with:

```
Error: The security token included in the request is invalid.
```

### Solution

Created `cleanup-feature.js` that uses the S3 SDK directly (same approach as deploy-v2.js):
- Uses `@aws-sdk/client-s3` to list and delete objects
- Reads credentials from GitHub secrets
- Supports both GitHub Actions and local testing
- Provides detailed logging and error handling

### Changes

- ✨ Added `cleanup-feature.js` - Node.js cleanup script using S3 SDK
- 🔧 Updated `.github/workflows/cleanup-feature.yml` to use the Node script
- 📝 Added `npm run cleanup` script for local testing

### Testing

Local test command:
```bash
npm run cleanup feature/branch-name
```

### Related

This completes the CI/CD workflow setup from PR #1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)