### PR TITLE
Release v0.2.0

### DIFF
--- a/dist/css-editor.js
+++ b/dist/css-editor.js
@@ -2312,6 +2312,58 @@ function attachEventListeners() {
         });
     });
 
+    // Add keyboard shortcuts for save functionality
+    document.addEventListener('keydown', (e) => {
+        // Check for Ctrl+S (Windows/Linux) or Cmd+S (Mac)
+        const isCtrlOrCmd = e.ctrlKey || e.metaKey;
+        const key = e.key.toLowerCase();
+
+        // Ctrl+Shift+S or Cmd+Shift+S: Save all tabs
+        if (isCtrlOrCmd && e.shiftKey && key === 's') {
+            e.preventDefault();
+            console.log('[Keyboard Shortcut] Ctrl+Shift+S detected - saving all tabs');
+            saveCSS();
+            return;
+        }
+
+        // Ctrl+S or Cmd+S: Save current focused tab
+        if (isCtrlOrCmd && !e.shiftKey && key === 's') {
+            e.preventDefault();
+            console.log('[Keyboard Shortcut] Ctrl+S detected - saving current tab');
+
+            // Find which editor currently has focus
+            let focusedRole = null;
+            for (const role in editorState) {
+                const state = editorState[role];
+                if (state.active && state.editor && state.editor.hasTextFocus()) {
+                    focusedRole = role;
+                    break;
+                }
+            }
+
+            if (focusedRole) {
+                console.log(`[Keyboard Shortcut] Saving focused editor: ${focusedRole}`);
+                saveSinglePane(focusedRole);
+            } else {
+                // No editor has focus - check if any editor is dirty and save the first dirty one
+                const dirtyRole = Object.keys(editorState).find(role =>
+                    editorState[role].active && editorState[role].isDirty
+                );
+
+                if (dirtyRole) {
+                    console.log(`[Keyboard Shortcut] No focused editor, saving first dirty editor: ${dirtyRole}`);
+                    saveSinglePane(dirtyRole);
+                } else {
+                    // No dirty editors - just save all
+                    console.log('[Keyboard Shortcut] No focused or dirty editor, saving all');
+                    saveCSS();
+                }
+            }
+            return;
+        }
+    });
+    console.log('[attachEventListeners] Keyboard shortcuts registered (Ctrl+S, Ctrl+Shift+S)');
+
     console.log('[CSS Editor] All event listeners registered');
 }
 // Expose for overlay embed to call after injecting HTML

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "expert-css-editor",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "expert-css-editor",
-      "version": "0.1.3",
+      "version": "0.2.0",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cxone-expert-enhancements",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Extensible toolkit loader for CXone Expert with modular enhancement modules including CSS editor, live preview, and more",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Release v0.2.0

### New Features

**Keyboard Shortcuts for Save Functionality** (#22)
- Added Ctrl+S (Cmd+S on Mac) to save currently focused editor tab
- Added Ctrl+Shift+S (Cmd+Shift+S on Mac) to save all tabs
- Smart fallback behavior when no tab has focus
- Prevents default browser save dialog

### Changes
- Enhanced workflow efficiency with keyboard shortcuts
- Improved developer experience for CSS editing

🤖 Generated with [Claude Code](https://claude.com/claude-code)