### PR TITLE
fix: Version check against target branch instead of develop

### DIFF
--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -22,21 +22,24 @@ jobs:
         run: |
           PR_VERSION=$(node -p "require('./package.json').version")
           echo "version=$PR_VERSION" >> $GITHUB_OUTPUT
-          echo "PR branch version: $PR_VERSION"
+          echo "PR branch (source) version: $PR_VERSION"
 
-      - name: Get develop branch version
-        id: develop_version
+      - name: Get target branch version
+        id: target_version
         run: |
-          git checkout origin/develop
-          DEVELOP_VERSION=$(node -p "require('./package.json').version")
-          echo "version=$DEVELOP_VERSION" >> $GITHUB_OUTPUT
-          echo "Develop branch version: $DEVELOP_VERSION"
+          TARGET_BRANCH="${{ github.base_ref }}"
+          echo "Target branch: $TARGET_BRANCH"
+          git checkout origin/$TARGET_BRANCH
+          TARGET_VERSION=$(node -p "require('./package.json').version")
+          echo "version=$TARGET_VERSION" >> $GITHUB_OUTPUT
+          echo "Target branch ($TARGET_BRANCH) version: $TARGET_VERSION"
 
       - name: Compare versions
         run: |
-          if [ "${{ steps.pr_version.outputs.version }}" == "${{ steps.develop_version.outputs.version }}" ]; then
+          TARGET_BRANCH="${{ github.base_ref }}"
+          if [ "${{ steps.pr_version.outputs.version }}" == "${{ steps.target_version.outputs.version }}" ]; then
             echo "❌ Version has not been bumped in package.json"
-            echo "Current develop version: ${{ steps.develop_version.outputs.version }}"
+            echo "Current $TARGET_BRANCH version: ${{ steps.target_version.outputs.version }}"
             echo "PR branch version: ${{ steps.pr_version.outputs.version }}"
             echo ""
             echo "Please bump the version using one of:"
@@ -45,5 +48,5 @@ jobs:
             echo "  npm version major  (for breaking changes)"
             exit 1
           else
-            echo "✅ Version bumped from ${{ steps.develop_version.outputs.version }} to ${{ steps.pr_version.outputs.version }}"
+            echo "✅ Version bumped from ${{ steps.target_version.outputs.version }} to ${{ steps.pr_version.outputs.version }}"
           fi


### PR DESCRIPTION
## Summary
Fixes version check workflow to compare against the correct target branch (main).

## Problem
The version check workflow was updated to only run on PRs to `main`, but it was still comparing the PR version against `develop` instead of the target branch (`main`).

This would cause incorrect version comparisons when creating release PRs.

## Solution
- Use `github.base_ref` to dynamically get the target branch
- Compare PR version against target branch version instead of hardcoded `develop`
- More robust and works for any target branch

## Changes
**File**: `.github/workflows/version-check.yml`

### Before:
```yaml
- name: Get develop branch version
  run: |
    git checkout origin/develop
    DEVELOP_VERSION=$(node -p "require('./package.json').version")
```

### After:
```yaml
- name: Get target branch version
  run: |
    TARGET_BRANCH="${{ github.base_ref }}"
    git checkout origin/$TARGET_BRANCH
    TARGET_VERSION=$(node -p "require('./package.json').version")
```

## Benefits
- ✅ Correctly compares PR version against target branch (main)
- ✅ Dynamic and works for any target branch
- ✅ More accurate error messages showing target branch name
- ✅ Fixes release PR version checks

## Testing
This fix will be validated when PR #32 (Release v1.2.0) runs the version check workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)