### PR TITLE
Fix cleanup workflow path

### DIFF
--- a/.github/workflows/cleanup-feature.yml
+++ b/.github/workflows/cleanup-feature.yml
@@ -37,7 +37,7 @@ jobs:
           DO_SPACES_ENDPOINT: ${{ vars.DO_SPACES_ENDPOINT }}
           GITHUB_HEAD_REF: ${{ github.head_ref }}
           GITHUB_ACTIONS: 'true'
-        run: node cleanup-feature.js
+        run: node deploy/cleanup-feature.js
 
       - name: Comment on PR
         uses: actions/github-script@v7


### PR DESCRIPTION
## Summary
Fixes the cleanup workflow to correctly reference the cleanup script location.

## Problem
The `cleanup-feature.yml` workflow was trying to run `node cleanup-feature.js` from the root directory, but the actual file is located at `deploy/cleanup-feature.js`.

This would cause the cleanup workflow to fail with:
```
Error: Cannot find module 'cleanup-feature.js'
```

## Solution
Updated the workflow to use the correct path: `node deploy/cleanup-feature.js`

## Impact
- ✅ Cleanup workflow will now successfully remove feature branch deployments when PRs are merged
- ✅ Prevents orphaned deployments on Digital Ocean Spaces
- ✅ No functional changes to the cleanup script itself

## Test Plan
- [ ] Merge this PR to develop
- [ ] Create and merge a test feature branch PR
- [ ] Verify cleanup workflow runs successfully
- [ ] Verify deployment is removed from Spaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)