### PR TITLE
feat: Exit fullscreen mode when manually resizing overlay

### DIFF
--- a/dist/expert-enhancements-core.js
+++ b/dist/expert-enhancements-core.js
@@ -1509,6 +1509,17 @@
             };
 
             const startResize = (e, handle) => {
+                // If in fullscreen mode, exit it before starting resize
+                if (isFullscreen) {
+                    console.log('[Overlay] Exiting fullscreen mode due to manual resize');
+                    isFullscreen = false;
+                    preFullscreenDimensions = null;
+                    Storage.setCommonState({
+                        isFullscreen: false,
+                        preFullscreenDimensions: null
+                    });
+                }
+
                 isResizing = true;
                 currentResizeHandle = handle;
                 resizeStartX = e.clientX;


### PR DESCRIPTION
## Summary
Implements automatic fullscreen exit when user grabs a resize handle, resolving issue #65.

## Changes
- Added fullscreen detection in `startResize()` function
- Clears fullscreen state before resize begins
- Updates localStorage to persist the change
- Allows new manual dimensions to be saved as normal size

## User Flow
1. User double-clicks header → enters fullscreen (95vw x 95vh)
2. User grabs any resize handle → **automatically exits fullscreen**
3. User resizes overlay → new size is saved as normal dimensions
4. User can double-click header again to re-enter fullscreen

## Benefits
✅ Intuitive UX - resizing exits fullscreen as expected
✅ No dimensional conflicts between fullscreen and manual resize
✅ Preserves user's manual size preference
✅ Fullscreen still accessible via double-click header

## Test Plan
- [ ] Load overlay and enter fullscreen mode (double-click header)
- [ ] Verify overlay expands to 95vw x 95vh
- [ ] While in fullscreen, grab any resize handle
- [ ] Verify console logs "Exiting fullscreen mode due to manual resize"
- [ ] Verify overlay exits fullscreen immediately
- [ ] Resize to custom dimensions
- [ ] Reload page and verify custom size persists
- [ ] Double-click header to re-enter fullscreen

## Testing URL
Once deployed, test at:
`https://releases.benelliot-nice.com/cxone-expert-enhancements/feature-fullscreen-resize-behavior/`

Resolves #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)