### PR TITLE
Fix: Remove duplicate HTML save toasts

### DIFF
--- a/dist/expert-enhancements-html.js
+++ b/dist/expert-enhancements-html.js
@@ -476,7 +476,6 @@
                 className: 'btn btn-primary',
                 id: 'save-btn'
             }, ['Save All']);
-            saveBtn.addEventListener('click', () => this.saveAll());
 
             const dropdownToggle = context.DOM.create('button', {
                 className: 'btn btn-dropdown-toggle',


### PR DESCRIPTION
## Summary
- Fixed duplicate toast notifications appearing when clicking "Save All" in HTML Editor
- Removed duplicate `addEventListener` call in `setupSaveDropdownStructure()`
- Now only one toast appears per save operation

## Root Cause
The "Save All" button had event listeners attached twice:
1. In `setupSaveDropdownStructure()` at line 479 (removed)
2. In `setupSaveDropdown()` at line 518 (kept)

This caused `saveAll()` to be called twice, showing 2 toasts.

## Changes
- **Removed** duplicate event listener from `setupSaveDropdownStructure()` in `dist/expert-enhancements-html.js`
- Now matches the pattern used in CSS Editor (fixed in PR #59)

## Test Plan
- [ ] Open HTML Editor
- [ ] Click "Save All" button
- [ ] Verify only **one** toast appears (not two)
- [ ] Test with both dirty and clean state
- [ ] Verify keyboard shortcut Ctrl+Shift+S also shows single toast

## Related
- Fixes #66
- Same issue pattern as #34 (CSS Editor, fixed in #59)

🤖 Generated with [Claude Code](https://claude.com/claude-code)